### PR TITLE
Fix memory leaks and performance problems in the source generator

### DIFF
--- a/BitsKit.Benchmarks/BitsKit.Benchmarks.csproj
+++ b/BitsKit.Benchmarks/BitsKit.Benchmarks.csproj
@@ -4,9 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <StartupObject>BitsKit.Benchmarks.Program</StartupObject>
-    <Platforms>AnyCPU;x86;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BitsKit.Generator/Analysers/BitFieldAnalyser.cs
+++ b/BitsKit.Generator/Analysers/BitFieldAnalyser.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Immutable;
+using BitsKit.Generator.Models;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace BitsKit.Generator
+namespace BitsKit.Generator.Analysers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class BitFieldAnalyser : DiagnosticAnalyzer
@@ -10,6 +11,7 @@ namespace BitsKit.Generator
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [
             DiagnosticDescriptors.ConflictingAccessors,
             DiagnosticDescriptors.ConflictingSetters,
+            DiagnosticDescriptors.EnumTypeExpected
         ];
         
         public override void Initialize(AnalysisContext context)
@@ -54,6 +56,17 @@ namespace BitsKit.Generator
                             context.ReportDiagnostic(
                                 Diagnostic.Create(DiagnosticDescriptors.ConflictingSetters, thisAttribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), fieldSymbol.ContainingType.Name, bitField.Name)
                             );
+                        }
+                        
+                        if (bitField is EnumFieldModel)
+                        {
+                            var enumFieldAttrModel = new EnumFieldAttributeModel(thisAttribute);
+                            if (enumFieldAttrModel.EnumType != null && enumFieldAttrModel.EnumType.EnumUnderlyingType == null)
+                            {
+                                context.ReportDiagnostic(
+                                    Diagnostic.Create(DiagnosticDescriptors.EnumTypeExpected, thisAttribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), fieldSymbol.ContainingType.Name, bitField.Name)
+                                );
+                            }
                         }
                     }
                 }, SymbolKind.Field);

--- a/BitsKit.Generator/Analysers/BitFieldAnalyser.cs
+++ b/BitsKit.Generator/Analysers/BitFieldAnalyser.cs
@@ -19,6 +19,9 @@ namespace BitsKit.Generator.Analysers
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             
+            // todo: reintroduce FieldTypeNotDefined
+            // but i'm not sure how it was triggered
+            
             context.RegisterCompilationStartAction(context =>
             {
                 var bitFieldAttribute = context.Compilation.GetTypeByMetadataName(StringConstants.BitFieldAttributeFullName);

--- a/BitsKit.Generator/Analysers/BitObjectAnalyser.cs
+++ b/BitsKit.Generator/Analysers/BitObjectAnalyser.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace BitsKit.Generator
+namespace BitsKit.Generator.Analysers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class BitObjectAnalyser : DiagnosticAnalyzer

--- a/BitsKit.Generator/BitFieldAnalyser.cs
+++ b/BitsKit.Generator/BitFieldAnalyser.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace BitsKit.Generator
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class BitFieldAnalyser : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [
+            DiagnosticDescriptors.ConflictingAccessors,
+            DiagnosticDescriptors.ConflictingSetters,
+        ];
+        
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            
+            context.RegisterCompilationStartAction(context =>
+            {
+                var bitFieldAttribute = context.Compilation.GetTypeByMetadataName(StringConstants.BitFieldAttributeFullName);
+                if (bitFieldAttribute == null) return;
+                
+                context.RegisterSymbolAction(context =>
+                {
+                    var fieldSymbol = (IFieldSymbol)context.Symbol;
+                    if (!fieldSymbol.TryGetAttributesWithBaseType(bitFieldAttribute, out var thisAttributes))
+                    {
+                        return;
+                    }
+
+                    foreach (var thisAttribute in thisAttributes)
+                    {
+                        // todo: code doesn't read the processor, just stores. so we don't need to give one
+                        var bitField = TypeSymbolProcessor.CreateBitFieldFromAttribute(thisAttribute, null!);
+                        if (bitField == null) continue;
+                        
+                        var accessorModifiers = bitField.Modifiers & BitFieldModifiers.AccessorMask;
+                        if ((accessorModifiers & (accessorModifiers - 1)) != 0 && 
+                            accessorModifiers != BitFieldModifiers.ProtectedInternal &&
+                            accessorModifiers != BitFieldModifiers.PrivateProtected)
+                        {
+                            // "protected internal" and "private protected" combos are allowed
+                            
+                            context.ReportDiagnostic(
+                                Diagnostic.Create(DiagnosticDescriptors.ConflictingAccessors, thisAttribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), fieldSymbol.ContainingType.Name, bitField.Name)
+                            );
+                        }
+                        
+                        var setterModifiers = bitField.Modifiers & BitFieldModifiers.SetterMask;
+                        if ((setterModifiers & (setterModifiers - 1)) != 0)
+                        {
+                            context.ReportDiagnostic(
+                                Diagnostic.Create(DiagnosticDescriptors.ConflictingSetters, thisAttribute.ApplicationSyntaxReference!.GetSyntax().GetLocation(), fieldSymbol.ContainingType.Name, bitField.Name)
+                            );
+                        }
+                    }
+                }, SymbolKind.Field);
+            });
+        }
+    }
+}

--- a/BitsKit.Generator/BitObjectAnalyser.cs
+++ b/BitsKit.Generator/BitObjectAnalyser.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace BitsKit.Generator
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class BitObjectAnalyser : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [
+            DiagnosticDescriptors.MustBePartial,
+            DiagnosticDescriptors.NestedNotAllowed
+        ];
+        
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            
+            context.RegisterCompilationStartAction(context =>
+            {
+                var bitObjectAttribute = context.Compilation.GetTypeByMetadataName("BitsKit.BitFields.BitObjectAttribute");
+                if (bitObjectAttribute == null) return;
+                
+                context.RegisterSymbolAction(context =>
+                {
+                    var type = (INamedTypeSymbol)context.Symbol;
+                    
+                    if (!type.TryGetAttributeWithType(bitObjectAttribute, out _))
+                    {
+                        return;
+                    }
+                    
+                    if (type.DeclaringSyntaxReferences[0].GetSyntax() is not TypeDeclarationSyntax typeDeclarationSyntax)
+                    {
+                        return;
+                    }
+                    
+                    if (!typeDeclarationSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword)))
+                    {
+                        context.ReportDiagnostic(
+                            Diagnostic.Create(DiagnosticDescriptors.MustBePartial, typeDeclarationSyntax.GetLocation(), type.Name)
+                        );
+                    }
+                    
+                    if (type.ContainingType != null)
+                    {
+                        context.ReportDiagnostic(
+                            Diagnostic.Create(DiagnosticDescriptors.NestedNotAllowed, typeDeclarationSyntax.GetLocation(), type.Name)
+                        );
+                    }
+                }, SymbolKind.NamedType);
+            });
+        }
+    }
+}

--- a/BitsKit.Generator/BitObjectAnalyser.cs
+++ b/BitsKit.Generator/BitObjectAnalyser.cs
@@ -22,7 +22,7 @@ namespace BitsKit.Generator
             
             context.RegisterCompilationStartAction(context =>
             {
-                var bitObjectAttribute = context.Compilation.GetTypeByMetadataName("BitsKit.BitFields.BitObjectAttribute");
+                var bitObjectAttribute = context.Compilation.GetTypeByMetadataName(StringConstants.BitObjectAttributeFullName);
                 if (bitObjectAttribute == null) return;
                 
                 context.RegisterSymbolAction(context =>

--- a/BitsKit.Generator/BitObjectGenerator.cs
+++ b/BitsKit.Generator/BitObjectGenerator.cs
@@ -22,10 +22,7 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
             .WithComparer(TypeSymbolProcessorComparer.Default)
             .Where(x => x is not null)!;
 
-        IncrementalValueProvider<(Compilation, ImmutableArray<TypeSymbolProcessor>)> model = context
-            .CompilationProvider
-            .Combine(typeDeclarations.Collect());
-
+        var model = typeDeclarations.Collect();
         context.RegisterSourceOutput(model, GenerateSourceCode);
     }
 
@@ -46,15 +43,15 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
         return new(typeSymbol, typeDeclaration, attribute);
     }
 
-    private static void GenerateSourceCode(SourceProductionContext context, (Compilation _, ImmutableArray<TypeSymbolProcessor> Processors) result)
+    private static void GenerateSourceCode(SourceProductionContext context, ImmutableArray<TypeSymbolProcessor> processors)
     {
-        if (result.Processors.Length == 0)
+        if (processors.Length == 0)
             return;
 
         StringBuilder stringBuilder = new(StringConstants.Header);
 
         // group the objects by their respective namespace
-        var namespaceGroups = result.Processors.GroupBy(x => x.Namespace);
+        var namespaceGroups = processors.GroupBy(x => x.Namespace);
 
         foreach (var namespaceGroup in namespaceGroups)
         {

--- a/BitsKit.Generator/BitObjectGenerator.cs
+++ b/BitsKit.Generator/BitObjectGenerator.cs
@@ -69,11 +69,6 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
                 if (processor.EnumerateFields() == 0)
                     continue;
 
-                // check and report any compilation issues and prevent
-                // code generation for this type if there are
-                if (processor.ReportCompilationIssues(context))
-                    continue;
-
                 processor.GenerateCSharpSource(stringBuilder);
             }
 

--- a/BitsKit.Generator/BitObjectGenerator.cs
+++ b/BitsKit.Generator/BitObjectGenerator.cs
@@ -19,7 +19,8 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
                 StringConstants.BitObjectAttributeFullName,
                 predicate: IsValidTypeDeclaration,
                 transform: ProcessSyntaxNode)
-            .Where(x => x is not null)!;
+            .Where(x => x is not null)
+            .WithTrackingName("Main")!;
 
         var model = typeDeclarations.Collect();
         context.RegisterSourceOutput(model, GenerateSourceCode);

--- a/BitsKit.Generator/BitObjectGenerator.cs
+++ b/BitsKit.Generator/BitObjectGenerator.cs
@@ -40,7 +40,7 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
             .GetAttributes()
             .Single(a => a.AttributeClass?.ToDisplayString() == StringConstants.BitObjectAttributeFullName);
 
-        return new(typeSymbol, typeDeclaration, attribute);
+        return new(typeSymbol, attribute);
     }
 
     private static void GenerateSourceCode(SourceProductionContext context, ImmutableArray<TypeSymbolProcessor> processors)

--- a/BitsKit.Generator/BitObjectGenerator.cs
+++ b/BitsKit.Generator/BitObjectGenerator.cs
@@ -19,7 +19,6 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
                 StringConstants.BitObjectAttributeFullName,
                 predicate: IsValidTypeDeclaration,
                 transform: ProcessSyntaxNode)
-            .WithComparer(TypeSymbolProcessorComparer.Default)
             .Where(x => x is not null)!;
 
         var model = typeDeclarations.Collect();
@@ -65,10 +64,6 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
 
             foreach (TypeSymbolProcessor processor in namespaceGroup)
             {
-                // evaluate if there are actually any valid fields
-                if (processor.EnumerateFields() == 0)
-                    continue;
-
                 processor.GenerateCSharpSource(stringBuilder);
             }
 
@@ -85,15 +80,4 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
 
     private static bool IsValidTypeDeclaration(SyntaxNode node, CancellationToken _) =>
         node is ClassDeclarationSyntax or StructDeclarationSyntax or RecordDeclarationSyntax;
-}
-
-file class TypeSymbolProcessorComparer : IEqualityComparer<TypeSymbolProcessor?>
-{
-    public static TypeSymbolProcessorComparer Default { get; } = new();
-
-    public bool Equals(TypeSymbolProcessor? x, TypeSymbolProcessor? y) =>
-        SymbolEqualityComparer.Default.Equals(x?.TypeSymbol, y?.TypeSymbol);
-
-    public int GetHashCode(TypeSymbolProcessor? obj) =>
-        SymbolEqualityComparer.Default.GetHashCode(obj?.TypeSymbol);
 }

--- a/BitsKit.Generator/BitObjectGenerator.cs
+++ b/BitsKit.Generator/BitObjectGenerator.cs
@@ -60,7 +60,7 @@ public sealed class BitObjectGenerator : IIncrementalGenerator
             // print the current namespace
             if (namespaceGroup.Key is not null)
                 stringBuilder
-                    .AppendLine($"namespace {namespaceGroup.Key.Name.ToFullString()}")
+                    .AppendLine($"namespace {namespaceGroup.Key}")
                     .AppendLine("{");
 
             foreach (TypeSymbolProcessor processor in namespaceGroup)

--- a/BitsKit.Generator/BitsKit.Generator.csproj
+++ b/BitsKit.Generator/BitsKit.Generator.csproj
@@ -3,10 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <LangVersion>preview</LangVersion>
-    <Nullable>enable</Nullable>
     <IsRoslynComponent>true</IsRoslynComponent>
-    <Platforms>AnyCPU;x86;x64</Platforms>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
     <EnforceExtendedAnalyzerRules>True</EnforceExtendedAnalyzerRules>
   </PropertyGroup>

--- a/BitsKit.Generator/BitsKit.Generator.csproj
+++ b/BitsKit.Generator/BitsKit.Generator.csproj
@@ -24,6 +24,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/BitsKit.Generator/BitsKit.Generator.csproj
+++ b/BitsKit.Generator/BitsKit.Generator.csproj
@@ -5,8 +5,6 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     <IsRoslynComponent>true</IsRoslynComponent>
     <Platforms>AnyCPU;x86;x64</Platforms>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>

--- a/BitsKit.Generator/BitsKit.Generator.csproj
+++ b/BitsKit.Generator/BitsKit.Generator.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="PolySharp" Version="1.15.0">

--- a/BitsKit.Generator/DiagnosticValidator.cs
+++ b/BitsKit.Generator/DiagnosticValidator.cs
@@ -26,15 +26,4 @@ internal static class DiagnosticValidator
                 typeName,
                 bitField.Name);
     }
-
-    public static bool IsNotEnumType(SourceProductionContext context, EnumFieldModel enumField, string typeName)
-    {
-        return enumField.EnumType is not { EnumUnderlyingType: { } }
-            && ReportDiagnostic(
-                context,
-                DiagnosticDescriptors.EnumTypeExpected,
-                enumField.BackingField.Locations[0],
-                typeName,
-                enumField.Name);
-    }
 }

--- a/BitsKit.Generator/DiagnosticValidator.cs
+++ b/BitsKit.Generator/DiagnosticValidator.cs
@@ -19,26 +19,6 @@ internal static class DiagnosticValidator
         return descriptor is { DefaultSeverity: DiagnosticSeverity.Error };
     }
 
-    public static bool IsNotPartial(SourceProductionContext context, TypeDeclarationSyntax typeDeclaration, string typeName)
-    {
-        return !typeDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword))
-            && ReportDiagnostic(
-                context,
-                DiagnosticDescriptors.MustBePartial,
-                typeDeclaration.GetLocation(),
-                typeName);
-    }
-
-    public static bool IsNested(SourceProductionContext context, TypeDeclarationSyntax typeDeclaration, string typeName)
-    {
-        return typeDeclaration.Parent is TypeDeclarationSyntax
-            && ReportDiagnostic(
-                context,
-                DiagnosticDescriptors.NestedNotAllowed,
-                typeDeclaration.GetLocation(),
-                typeName);
-    }
-
     public static bool HasMissingFieldType(SourceProductionContext context, BitFieldModel bitField, string typeName)
     {
         return bitField.FieldType is null

--- a/BitsKit.Generator/DiagnosticValidator.cs
+++ b/BitsKit.Generator/DiagnosticValidator.cs
@@ -1,7 +1,4 @@
-﻿using System.Linq;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis;
 using BitsKit.Generator.Models;
 
 namespace BitsKit.Generator;
@@ -25,36 +22,6 @@ internal static class DiagnosticValidator
             && ReportDiagnostic(
                 context,
                 DiagnosticDescriptors.FieldTypeNotDefined,
-                bitField.BackingField.Locations[0],
-                typeName,
-                bitField.Name);
-    }
-
-    public static bool HasConflictingAccessors(SourceProductionContext context, BitFieldModel bitField, string typeName)
-    {
-        BitFieldModifiers modifiers = bitField.Modifiers & BitFieldModifiers.AccessorMask;
-
-        // "protected internal" and "private protected" combos are allowed
-        if (modifiers is BitFieldModifiers.ProtectedInternal or BitFieldModifiers.PrivateProtected)
-            return false;
-
-        return (modifiers & (modifiers - 1)) != 0
-            && ReportDiagnostic(
-                context,
-                DiagnosticDescriptors.ConflictingAccessors,
-                bitField.BackingField.Locations[0],
-                typeName,
-                bitField.Name);
-    }
-
-    public static bool HasConflictingSetters(SourceProductionContext context, BitFieldModel bitField, string typeName)
-    {
-        BitFieldModifiers modifiers = bitField.Modifiers & BitFieldModifiers.SetterMask;
-
-        return (modifiers & (modifiers - 1)) != 0
-            && ReportDiagnostic(
-                context,
-                DiagnosticDescriptors.ConflictingSetters,
                 bitField.BackingField.Locations[0],
                 typeName,
                 bitField.Name);

--- a/BitsKit.Generator/DiagnosticValidator.cs
+++ b/BitsKit.Generator/DiagnosticValidator.cs
@@ -16,7 +16,7 @@ internal static class DiagnosticValidator
         return descriptor is { DefaultSeverity: DiagnosticSeverity.Error };
     }
 
-    public static bool HasMissingFieldType(SourceProductionContext context, BitFieldModel bitField, string typeName)
+    /*public static bool HasMissingFieldType(SourceProductionContext context, BitFieldModel bitField, string typeName)
     {
         return bitField.FieldType is null
             && ReportDiagnostic(
@@ -25,5 +25,5 @@ internal static class DiagnosticValidator
                 bitField.BackingField.Locations[0],
                 typeName,
                 bitField.Name);
-    }
+    }*/
 }

--- a/BitsKit.Generator/EquatableReadOnlyList.cs
+++ b/BitsKit.Generator/EquatableReadOnlyList.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace BitsKit.Generator
+{
+    [ExcludeFromCodeCoverage]
+    public static class EquatableReadOnlyList
+    {
+        public static EquatableReadOnlyList<T> ToEquatableReadOnlyList<T>(this IEnumerable<T> enumerable)
+            => new(enumerable is IReadOnlyList<T> l ? l : [.. enumerable]);
+    }
+
+    /// <summary>
+    ///     A wrapper for IReadOnlyList that provides value equality support for the wrapped list.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public readonly struct EquatableReadOnlyList<T>(
+        IReadOnlyList<T>? collection
+    ) : IEquatable<EquatableReadOnlyList<T>>, IReadOnlyList<T>
+    {
+        private IReadOnlyList<T> Collection => collection ?? [];
+
+        public bool Equals(EquatableReadOnlyList<T> other)
+            => this.SequenceEqual(other);
+
+        public override bool Equals(object? obj)
+            => obj is EquatableReadOnlyList<T> other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+
+            foreach (var item in Collection)
+                hashCode.Add(item);
+
+            return hashCode.ToHashCode();
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+            => Collection.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => Collection.GetEnumerator();
+
+        public int Count => Collection.Count;
+        public T this[int index] => Collection[index];
+
+        public static bool operator ==(EquatableReadOnlyList<T> left, EquatableReadOnlyList<T> right)
+            => left.Equals(right);
+
+        public static bool operator !=(EquatableReadOnlyList<T> left, EquatableReadOnlyList<T> right)
+            => !left.Equals(right);
+    }
+}

--- a/BitsKit.Generator/Models/BackingFieldModel.cs
+++ b/BitsKit.Generator/Models/BackingFieldModel.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace BitsKit.Generator.Models
+{
+    internal record BackingFieldModel
+    {
+        public readonly string Name;
+        public readonly string TypeString;
+        public readonly int FixedSize;
+        public readonly bool IsReadOnly;
+        
+        public readonly BackingFieldType Type;
+
+        public BackingFieldModel(IFieldSymbol fieldSymbol, BackingFieldType type)
+        {
+            Name = fieldSymbol.Name;
+            TypeString = fieldSymbol.Type.ToDisplayString();
+            FixedSize = fieldSymbol.FixedSize;
+            IsReadOnly = fieldSymbol.IsReadOnly;
+            
+            Type = type;
+        }
+    }
+}

--- a/BitsKit.Generator/Models/BitFieldModel.cs
+++ b/BitsKit.Generator/Models/BitFieldModel.cs
@@ -200,7 +200,7 @@ internal abstract class BitFieldModel
     /// <returns></returns>
     private bool SupportsReadOnlyGetter()
     {
-        return TypeSymbol.TypeDeclaration.IsStruct() &&
+        return TypeSymbol.IsStruct &&
                BackingFieldType != BackingFieldType.Pointer &&
                BackingFieldType != BackingFieldType.InlineArray &&
                !IsReadOnly();

--- a/BitsKit.Generator/Models/BitFieldModel.cs
+++ b/BitsKit.Generator/Models/BitFieldModel.cs
@@ -9,8 +9,8 @@ internal abstract class BitFieldModel
     public string Name { get; set; } = null!;
     public BitFieldType? FieldType { get; set; }
     public string? ReturnType { get; set; }
-    public IFieldSymbol BackingField { get; set; } = null!;
-    public BackingFieldType BackingFieldType { get; set; }
+    public BackingFieldModel BackingField { get; set; } = null!;
+    public BackingFieldType BackingFieldType => BackingField.Type;
     public int BitOffset { get; set; }
     public int BitCount { get; set; }
     public BitOrder BitOrder { get; set; }
@@ -54,7 +54,7 @@ internal abstract class BitFieldModel
             GetPropertyTemplate(),
             accessor,
             Modifiers.HasFlag(BitFieldModifiers.Required) ? "required" : "",
-            ReturnType ?? FieldType.ToString(),
+            ReturnType ?? FieldType?.ToString(),
             Name)
           .AppendIndentedLine(2, "{");
 
@@ -64,13 +64,13 @@ internal abstract class BitFieldModel
                 GetGetterTemplate(),
                 SupportsReadOnlyGetter() ? "readonly" : "",
                 "get",
-                FieldType!.Value.ToIntegralName(),
+                FieldType?.ToIntegralName(),
                 BitOrder.ToShortName(),
                 BackingField.Name,
                 BitOffset,
                 BitCount,
                 BackingField.FixedSize,
-                BackingField.Type);
+                BackingField.TypeString);
         }
 
         // setter
@@ -80,25 +80,17 @@ internal abstract class BitFieldModel
                 GetSetterTemplate(),
                 "",
                 Modifiers.HasFlag(BitFieldModifiers.InitOnly) ? "init" : "set",
-                FieldType!.Value.ToIntegralName(),
+                FieldType?.ToIntegralName(),
                 BitOrder.ToShortName(),
                 BackingField.Name,
                 BitOffset,
                 BitCount,
                 BackingField.FixedSize,
-                BackingField.Type);
+                BackingField.TypeString);
         }
 
         sb.AppendIndentedLine(2, "}")
           .AppendLine();
-    }
-
-    /// <summary>
-    /// Diagnoses if the field will produce non-compilable or erroneous code
-    /// </summary>
-    public virtual bool HasCompilationIssues(SourceProductionContext context, TypeSymbolProcessor processor)
-    {
-        return DiagnosticValidator.HasMissingFieldType(context, this, processor.TypeSymbol.Name);
     }
 
     /// <summary>
@@ -186,7 +178,7 @@ internal abstract class BitFieldModel
     /// </summary>
     protected bool IsReadOnly()
     {
-        string backingType = BackingField.Type.ToDisplayString();
+        string backingType = BackingField.TypeString;
 
         return BackingField.IsReadOnly ||
                backingType == "System.ReadOnlySpan<byte>" ||

--- a/BitsKit.Generator/Models/BitFieldModel.cs
+++ b/BitsKit.Generator/Models/BitFieldModel.cs
@@ -98,9 +98,7 @@ internal abstract class BitFieldModel
     /// </summary>
     public virtual bool HasCompilationIssues(SourceProductionContext context, TypeSymbolProcessor processor)
     {
-        return DiagnosticValidator.HasMissingFieldType(context, this, processor.TypeSymbol.Name) |
-               DiagnosticValidator.HasConflictingAccessors(context, this, processor.TypeSymbol.Name) |
-               DiagnosticValidator.HasConflictingSetters(context, this, processor.TypeSymbol.Name);
+        return DiagnosticValidator.HasMissingFieldType(context, this, processor.TypeSymbol.Name);
     }
 
     /// <summary>

--- a/BitsKit.Generator/Models/BitFieldModel.cs
+++ b/BitsKit.Generator/Models/BitFieldModel.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 
 namespace BitsKit.Generator.Models;
 
-internal abstract class BitFieldModel
+internal abstract record BitFieldModel
 {
     public string Name { get; set; } = null!;
     public BitFieldType? FieldType { get; set; }
@@ -16,11 +16,19 @@ internal abstract class BitFieldModel
     public BitOrder BitOrder { get; set; }
     public bool ReverseBitOrder { get; }
     public BitFieldModifiers Modifiers { get; }
-    public TypeSymbolProcessor TypeSymbol { get; }
+    
+    private readonly bool _containingTypeIsStruct;
 
-    public BitFieldModel(AttributeData attributeData, TypeSymbolProcessor typeSymbol)
+    public BitFieldModel(AttributeData attributeData, TypeSymbolProcessor? typeSymbol)
     {
-        TypeSymbol = typeSymbol;
+        if (typeSymbol != null)
+        {
+            // todo: for now, analyser passes null
+            // these fields don't matter for it
+            
+            _containingTypeIsStruct = typeSymbol.IsStruct;
+            BitOrder = typeSymbol.DefaultBitOrder;
+        }
 
         for (int i = 0; i < attributeData.NamedArguments.Length; i++)
         {
@@ -192,7 +200,7 @@ internal abstract class BitFieldModel
     /// <returns></returns>
     private bool SupportsReadOnlyGetter()
     {
-        return TypeSymbol.IsStruct &&
+        return _containingTypeIsStruct &&
                BackingFieldType != BackingFieldType.Pointer &&
                BackingFieldType != BackingFieldType.InlineArray &&
                !IsReadOnly();

--- a/BitsKit.Generator/Models/BooleanFieldModel.cs
+++ b/BitsKit.Generator/Models/BooleanFieldModel.cs
@@ -5,9 +5,9 @@ namespace BitsKit.Generator.Models;
 /// <summary>
 /// A model representing a boolean bit-field
 /// </summary>
-internal sealed class BooleanFieldModel : BitFieldModel
+internal sealed record BooleanFieldModel : BitFieldModel
 {
-    public BooleanFieldModel(AttributeData attributeData, TypeSymbolProcessor typeSymbol) : base(attributeData, typeSymbol)
+    public BooleanFieldModel(AttributeData attributeData, TypeSymbolProcessor? typeSymbol) : base(attributeData, typeSymbol)
     {
         switch (attributeData.ConstructorArguments.Length)
         {

--- a/BitsKit.Generator/Models/EnumFieldModel.cs
+++ b/BitsKit.Generator/Models/EnumFieldModel.cs
@@ -1,15 +1,18 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.IO;
+using Microsoft.CodeAnalysis;
 
 namespace BitsKit.Generator.Models;
 
 /// <summary>
-/// A model representing an enum bit-field
+/// Parsed data from EnumFieldAttribute. Intermediate data only (don't store in incremental pipeline)
 /// </summary>
-internal sealed class EnumFieldModel : BitFieldModel
+internal class EnumFieldAttributeModel
 {
+    public string? Name { get; }
     public INamedTypeSymbol? EnumType { get; }
-
-    public EnumFieldModel(AttributeData attributeData, TypeSymbolProcessor typeSymbol) : base(attributeData, typeSymbol)
+    public int BitCount { get; set; }
+    
+    public EnumFieldAttributeModel(AttributeData attributeData)
     {
         switch(attributeData.ConstructorArguments.Length)
         {
@@ -22,20 +25,27 @@ internal sealed class EnumFieldModel : BitFieldModel
                 EnumType = attributeData.ConstructorArguments[2].Value as INamedTypeSymbol;
                 break;
             default:
-                return;
+                throw new InvalidDataException($"unknown number of enum attribute constructor arguments: {attributeData.ConstructorArguments.Length}");
         }
+    }
+}
 
-        ReturnType = EnumType?.ToDisplayString();
-        FieldType = EnumType?.EnumUnderlyingType?.SpecialType.ToBitFieldType();
+/// <summary>
+/// A model representing an enum bit-field
+/// </summary>
+internal sealed class EnumFieldModel : BitFieldModel
+{
+    public EnumFieldModel(AttributeData attributeData, TypeSymbolProcessor typeSymbol) : base(attributeData, typeSymbol)
+    {
+        var attributeModel = new EnumFieldAttributeModel(attributeData);
+        Name = attributeModel.Name!; // todo: the nullability on this is well.. wrong. padding fields have no name
+        BitCount = attributeModel.BitCount;
+        
+        ReturnType = attributeModel.EnumType?.ToDisplayString();
+        FieldType = attributeModel.EnumType?.EnumUnderlyingType?.SpecialType.ToBitFieldType();
 
         if (string.IsNullOrEmpty(Name))
             FieldType = BitFieldType.Padding;
-    }
-
-    public override bool HasCompilationIssues(SourceProductionContext context, TypeSymbolProcessor processor)
-    {
-        return DiagnosticValidator.IsNotEnumType(context, this, processor.TypeSymbol.Name) |
-               base.HasCompilationIssues(context, processor);
     }
 
     protected override string GetGetterTemplate()

--- a/BitsKit.Generator/Models/EnumFieldModel.cs
+++ b/BitsKit.Generator/Models/EnumFieldModel.cs
@@ -33,9 +33,9 @@ internal class EnumFieldAttributeModel
 /// <summary>
 /// A model representing an enum bit-field
 /// </summary>
-internal sealed class EnumFieldModel : BitFieldModel
+internal sealed record EnumFieldModel : BitFieldModel
 {
-    public EnumFieldModel(AttributeData attributeData, TypeSymbolProcessor typeSymbol) : base(attributeData, typeSymbol)
+    public EnumFieldModel(AttributeData attributeData, TypeSymbolProcessor? typeSymbol) : base(attributeData, typeSymbol)
     {
         var attributeModel = new EnumFieldAttributeModel(attributeData);
         Name = attributeModel.Name!; // todo: the nullability on this is well.. wrong. padding fields have no name

--- a/BitsKit.Generator/Models/IntegralFieldModel.cs
+++ b/BitsKit.Generator/Models/IntegralFieldModel.cs
@@ -5,7 +5,7 @@ namespace BitsKit.Generator.Models;
 /// <summary>
 /// A model representing an integral bit-field
 /// </summary>
-internal sealed class IntegralFieldModel : BitFieldModel
+internal sealed record IntegralFieldModel : BitFieldModel
 {
     private bool IsTypeCast => this is
     {
@@ -13,7 +13,7 @@ internal sealed class IntegralFieldModel : BitFieldModel
         ReturnType.Length: > 0
     };
 
-    public IntegralFieldModel(AttributeData attributeData, TypeSymbolProcessor typeSymbol) : base(attributeData, typeSymbol)
+    public IntegralFieldModel(AttributeData attributeData, TypeSymbolProcessor? typeSymbol) : base(attributeData, typeSymbol)
     {
         switch (attributeData.ConstructorArguments.Length)
         {

--- a/BitsKit.Generator/Properties/launchSettings.json
+++ b/BitsKit.Generator/Properties/launchSettings.json
@@ -1,8 +1,8 @@
 {
   "profiles": {
-    "Profile 1": {
+    "Debug Source Generator - on BitsKit.Tests": {
       "commandName": "DebugRoslynComponent",
-      "targetProject": "..\\BitsKit.Generator.Tests\\BitsKit.Generator.Tests.csproj"
+      "targetProject": "..\\BitsKit.Tests\\BitsKit.Tests.csproj"
     }
   }
 }

--- a/BitsKit.Generator/StringConstants.cs
+++ b/BitsKit.Generator/StringConstants.cs
@@ -31,13 +31,11 @@ internal static class StringConstants
     /// <summary>
     /// Template for the type declaration
     /// <para>
-    /// {0} = Modifiers<br/>
-    /// {1} = Keyword<br/>
-    /// {2} = Record ClassOrStructKeyword<br/>
-    /// {3} = Identifier 
+    /// {0} = Keyword<br/>
+    /// {1} = Identifier 
     /// </para>
     /// </summary>
-    public const string TypeDeclarationTemplate = "{0} {1} {2} {3}";
+    public const string TypeDeclarationTemplate = "partial {0} {1}";
 
     /// <summary>
     /// Template for a property declaration

--- a/BitsKit.Generator/SymbolExtensions.cs
+++ b/BitsKit.Generator/SymbolExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 
 namespace BitsKit.Generator
@@ -19,6 +20,30 @@ namespace BitsKit.Generator
 
             attributeData = null;
             return false;
+        }
+        
+        public static bool TryGetAttributesWithBaseType(this ISymbol symbol, ITypeSymbol typeSymbol, [NotNullWhen(true)] out List<AttributeData>? result)
+        {
+            result = null;
+            
+            foreach (AttributeData attribute in symbol.GetAttributes())
+            {
+                var attributeClass = attribute.AttributeClass!;
+                do
+                {
+                    if (SymbolEqualityComparer.Default.Equals(attributeClass, typeSymbol))
+                    {
+                        result ??= [];
+                        result.Add(attribute);
+                        break;
+                    }
+                    
+                    attributeClass = attributeClass.BaseType;
+                } while (attributeClass != null);
+                
+            }
+
+            return result != null;
         }
     }
 }

--- a/BitsKit.Generator/SymbolExtensions.cs
+++ b/BitsKit.Generator/SymbolExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+
+namespace BitsKit.Generator
+{
+    public static class SymbolExtensions
+    {
+        public static bool TryGetAttributeWithType(this ISymbol symbol, ITypeSymbol typeSymbol, [NotNullWhen(true)] out AttributeData? attributeData)
+        {
+            foreach (AttributeData attribute in symbol.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, typeSymbol))
+                {
+                    attributeData = attribute;
+
+                    return true;
+                }
+            }
+
+            attributeData = null;
+            return false;
+        }
+    }
+}

--- a/BitsKit.Generator/TypeSymbolProcessor.cs
+++ b/BitsKit.Generator/TypeSymbolProcessor.cs
@@ -12,7 +12,7 @@ internal sealed class TypeSymbolProcessor
     public INamedTypeSymbol TypeSymbol { get; }
     public TypeDeclarationSyntax TypeDeclaration { get; }
     public IReadOnlyList<BitFieldModel> Fields => _fields;
-    public BaseNamespaceDeclarationSyntax? Namespace { get; }
+    public string? Namespace { get; }
     public bool IsInlineArray { get; }
 
     private readonly BitOrder _defaultBitOrder;
@@ -22,7 +22,10 @@ internal sealed class TypeSymbolProcessor
     {
         TypeSymbol = typeSymbol;
         TypeDeclaration = typeDeclaration;
-        Namespace = TypeDeclaration.Parent as BaseNamespaceDeclarationSyntax;
+        
+        Namespace = typeSymbol.ContainingNamespace.ToDisplayString(new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces));
+        if (string.IsNullOrWhiteSpace(Namespace)) Namespace = null;
+        
         IsInlineArray = HasInlineArrayAttribute();
 
         _defaultBitOrder = (BitOrder)attribute.ConstructorArguments[0].Value!;

--- a/BitsKit.Generator/TypeSymbolProcessor.cs
+++ b/BitsKit.Generator/TypeSymbolProcessor.cs
@@ -84,10 +84,6 @@ internal sealed class TypeSymbolProcessor
     {
         bool hasCompilationIssues = false;
 
-        if (DiagnosticValidator.IsNotPartial(context, TypeDeclaration, TypeSymbol.Name) |
-            DiagnosticValidator.IsNested(context, TypeDeclaration, TypeSymbol.Name))
-            hasCompilationIssues = true;
-
         foreach (BitFieldModel field in _fields)
         {
             if (field.HasCompilationIssues(context, this))

--- a/BitsKit.Generator/TypeSymbolProcessor.cs
+++ b/BitsKit.Generator/TypeSymbolProcessor.cs
@@ -99,15 +99,7 @@ internal sealed class TypeSymbolProcessor
 
         foreach (AttributeData attribute in backingField.GetAttributes())
         {
-            string? attributeType = attribute.AttributeClass?.ToDisplayString();
-
-            BitFieldModel? bitField = attributeType switch
-            {
-                StringConstants.BitFieldAttributeFullName => new IntegralFieldModel(attribute, this),
-                StringConstants.BooleanFieldAttributeFullName => new BooleanFieldModel(attribute, this),
-                StringConstants.EnumFieldAttributeFullName => new EnumFieldModel(attribute, this),
-                _ => null
-            };
+            BitFieldModel? bitField = CreateBitFieldFromAttribute(attribute, this);
 
             if (bitField == null)
                 continue;
@@ -138,6 +130,19 @@ internal sealed class TypeSymbolProcessor
 
             offset += bitField.BitCount;
         }
+    }
+    
+    public static BitFieldModel? CreateBitFieldFromAttribute(AttributeData attribute, TypeSymbolProcessor processor)
+    {
+        string? attributeType = attribute.AttributeClass?.ToDisplayString();
+            
+        return attributeType switch
+        {
+            StringConstants.BitFieldAttributeFullName => new IntegralFieldModel(attribute, processor),
+            StringConstants.BooleanFieldAttributeFullName => new BooleanFieldModel(attribute, processor),
+            StringConstants.EnumFieldAttributeFullName => new EnumFieldModel(attribute, processor),
+            _ => null
+        };
     }
 
     private bool HasInlineArrayAttribute()

--- a/BitsKit.Generator/TypeSymbolProcessor.cs
+++ b/BitsKit.Generator/TypeSymbolProcessor.cs
@@ -11,10 +11,11 @@ internal sealed class TypeSymbolProcessor
     public INamedTypeSymbol TypeSymbol { get; }
     public IReadOnlyList<BitFieldModel> Fields => _fields;
     public string? Namespace { get; }
+    
+    public BitOrder DefaultBitOrder { get; }
     public bool IsStruct { get; }
     public bool IsInlineArray { get; }
 
-    private readonly BitOrder _defaultBitOrder;
     private readonly List<BitFieldModel> _fields = [];
     
     private readonly string _syntaxKeyword;
@@ -37,10 +38,9 @@ internal sealed class TypeSymbolProcessor
         Namespace = typeSymbol.ContainingNamespace.ToDisplayString(new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces));
         if (string.IsNullOrWhiteSpace(Namespace)) Namespace = null;
         
+        DefaultBitOrder = (BitOrder)attribute.ConstructorArguments[0].Value!;
         IsStruct = typeSymbol.TypeKind == TypeKind.Struct;
         IsInlineArray = HasInlineArrayAttribute();
-
-        _defaultBitOrder = (BitOrder)attribute.ConstructorArguments[0].Value!;
     }
 
     public void GenerateCSharpSource(StringBuilder sb)
@@ -107,7 +107,6 @@ internal sealed class TypeSymbolProcessor
 
             bitField.BackingField = backingModel;
             bitField.BitOffset = offset;
-            bitField.BitOrder = _defaultBitOrder;
 
             // padding fields are not generated
             if (bitField is not { FieldType: BitFieldType.Padding })

--- a/BitsKit.Generator/TypeSymbolProcessor.cs
+++ b/BitsKit.Generator/TypeSymbolProcessor.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis;
 using System.Text;
 using BitsKit.Generator.Models;
@@ -10,22 +9,35 @@ namespace BitsKit.Generator;
 internal sealed class TypeSymbolProcessor
 {
     public INamedTypeSymbol TypeSymbol { get; }
-    public TypeDeclarationSyntax TypeDeclaration { get; }
     public IReadOnlyList<BitFieldModel> Fields => _fields;
     public string? Namespace { get; }
+    public bool IsStruct { get; }
     public bool IsInlineArray { get; }
 
     private readonly BitOrder _defaultBitOrder;
     private readonly List<BitFieldModel> _fields = [];
+    
+    private readonly string _syntaxKeyword;
+    private readonly string _syntaxIdentifier;
 
-    public TypeSymbolProcessor(INamedTypeSymbol typeSymbol, TypeDeclarationSyntax typeDeclaration, AttributeData attribute)
+    public TypeSymbolProcessor(INamedTypeSymbol typeSymbol, AttributeData attribute)
     {
         TypeSymbol = typeSymbol;
-        TypeDeclaration = typeDeclaration;
+        
+        _syntaxKeyword = typeSymbol.TypeKind switch
+        {
+            TypeKind.Struct when typeSymbol.IsRecord => "record struct",
+            TypeKind.Struct => "struct",
+            TypeKind.Interface => "interface",
+            TypeKind.Class when typeSymbol.IsRecord => "record",
+            _ => "class"
+        };
+        _syntaxIdentifier = typeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
         
         Namespace = typeSymbol.ContainingNamespace.ToDisplayString(new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces));
         if (string.IsNullOrWhiteSpace(Namespace)) Namespace = null;
         
+        IsStruct = typeSymbol.TypeKind == TypeKind.Struct;
         IsInlineArray = HasInlineArrayAttribute();
 
         _defaultBitOrder = (BitOrder)attribute.ConstructorArguments[0].Value!;
@@ -35,10 +47,8 @@ internal sealed class TypeSymbolProcessor
     {
         sb.AppendIndentedLine(1,
             StringConstants.TypeDeclarationTemplate,
-            TypeDeclaration.Modifiers,
-            TypeDeclaration.Keyword.Text,
-            (TypeDeclaration as RecordDeclarationSyntax)?.ClassOrStructKeyword.Text,
-            TypeDeclaration.Identifier.Text)
+            _syntaxKeyword,
+            _syntaxIdentifier)
           .AppendIndentedLine(1, "{");
 
         foreach (BitFieldModel field in _fields)

--- a/BitsKit.Generator/TypeSymbolProcessor.cs
+++ b/BitsKit.Generator/TypeSymbolProcessor.cs
@@ -8,14 +8,12 @@ namespace BitsKit.Generator;
 
 internal sealed record TypeSymbolProcessor
 {
-    public IReadOnlyList<BitFieldModel> Fields => _fields; // todo: eq
+    public EquatableReadOnlyList<BitFieldModel> Fields { get; }
     public string? Namespace { get; }
     
     public BitOrder DefaultBitOrder { get; }
     public bool IsStruct { get; }
     public bool IsInlineArray { get; }
-
-    private readonly List<BitFieldModel> _fields = [];
     
     private readonly string _syntaxKeyword;
     private readonly string _syntaxIdentifier;
@@ -39,7 +37,7 @@ internal sealed record TypeSymbolProcessor
         IsStruct = typeSymbol.TypeKind == TypeKind.Struct;
         IsInlineArray = HasInlineArrayAttribute(typeSymbol);
         
-        EnumerateFields(typeSymbol);
+        Fields = EnumerateFields(typeSymbol);
     }
 
     public void GenerateCSharpSource(StringBuilder sb)
@@ -50,7 +48,7 @@ internal sealed record TypeSymbolProcessor
             _syntaxIdentifier)
           .AppendIndentedLine(1, "{");
 
-        foreach (BitFieldModel field in _fields)
+        foreach (BitFieldModel field in Fields)
             field.GenerateCSharpSource(sb);
 
         sb.RemoveLastLine()
@@ -58,9 +56,9 @@ internal sealed record TypeSymbolProcessor
           .AppendLine();
     }
 
-    private int EnumerateFields(ITypeSymbol typeSymbol)
+    private EquatableReadOnlyList<BitFieldModel> EnumerateFields(ITypeSymbol typeSymbol)
     {
-        _fields.Clear();
+        var output = new List<BitFieldModel>();
 
         foreach (IFieldSymbol field in typeSymbol.GetMembers().OfType<IFieldSymbol>())
         {
@@ -87,13 +85,13 @@ internal sealed record TypeSymbolProcessor
                 continue;
 
             var backingModel = new BackingFieldModel(field, backingType);
-            CreateBitFieldModels(field, backingModel);
+            CreateBitFieldModels(output, field, backingModel);
         }
 
-        return _fields.Count;
+        return output.ToEquatableReadOnlyList();
     }
 
-    private void CreateBitFieldModels(IFieldSymbol backingField, BackingFieldModel backingModel)
+    private void CreateBitFieldModels(List<BitFieldModel> output, IFieldSymbol backingField, BackingFieldModel backingModel)
     {
         int offset = 0;
 
@@ -123,7 +121,7 @@ internal sealed record TypeSymbolProcessor
                     bitField.FieldType ??= backingField.Type.SpecialType.ToBitFieldType();
 
                 // add to list of fields to generate
-                _fields.Add(bitField);
+                output.Add(bitField);
             }
 
             offset += bitField.BitCount;

--- a/BitsKit.Generator/TypeSymbolProcessor.cs
+++ b/BitsKit.Generator/TypeSymbolProcessor.cs
@@ -87,26 +87,14 @@ internal sealed class TypeSymbolProcessor
             if (backingType == BackingFieldType.Invalid)
                 continue;
 
-            CreateBitFieldModels(field, backingType);
+            var backingModel = new BackingFieldModel(field, backingType);
+            CreateBitFieldModels(field, backingModel);
         }
 
         return _fields.Count;
     }
 
-    public bool ReportCompilationIssues(SourceProductionContext context)
-    {
-        bool hasCompilationIssues = false;
-
-        foreach (BitFieldModel field in _fields)
-        {
-            if (field.HasCompilationIssues(context, this))
-                hasCompilationIssues = true;
-        }
-
-        return hasCompilationIssues;
-    }
-
-    private void CreateBitFieldModels(IFieldSymbol backingField, BackingFieldType backingType)
+    private void CreateBitFieldModels(IFieldSymbol backingField, BackingFieldModel backingModel)
     {
         int offset = 0;
 
@@ -117,8 +105,7 @@ internal sealed class TypeSymbolProcessor
             if (bitField == null)
                 continue;
 
-            bitField.BackingField = backingField;
-            bitField.BackingFieldType = backingType;
+            bitField.BackingField = backingModel;
             bitField.BitOffset = offset;
             bitField.BitOrder = _defaultBitOrder;
 
@@ -130,11 +117,11 @@ internal sealed class TypeSymbolProcessor
                     bitField.BitOrder ^= BitOrder.MostSignificant;
 
                 // integrals inherit their field type from their backing field
-                if (backingType == BackingFieldType.Integral)
+                if (backingModel.Type == BackingFieldType.Integral)
                     bitField.FieldType = backingField.Type.SpecialType.ToBitFieldType();
 
                 // allow inline arrays to infer their type
-                if (backingType == BackingFieldType.InlineArray)
+                if (backingModel.Type == BackingFieldType.InlineArray)
                     bitField.FieldType ??= backingField.Type.SpecialType.ToBitFieldType();
 
                 // add to list of fields to generate

--- a/BitsKit.Generator/TypeSymbolProcessor.cs
+++ b/BitsKit.Generator/TypeSymbolProcessor.cs
@@ -6,10 +6,9 @@ using System.Linq;
 
 namespace BitsKit.Generator;
 
-internal sealed class TypeSymbolProcessor
+internal sealed record TypeSymbolProcessor
 {
-    public INamedTypeSymbol TypeSymbol { get; }
-    public IReadOnlyList<BitFieldModel> Fields => _fields;
+    public IReadOnlyList<BitFieldModel> Fields => _fields; // todo: eq
     public string? Namespace { get; }
     
     public BitOrder DefaultBitOrder { get; }
@@ -23,8 +22,6 @@ internal sealed class TypeSymbolProcessor
 
     public TypeSymbolProcessor(INamedTypeSymbol typeSymbol, AttributeData attribute)
     {
-        TypeSymbol = typeSymbol;
-        
         _syntaxKeyword = typeSymbol.TypeKind switch
         {
             TypeKind.Struct when typeSymbol.IsRecord => "record struct",
@@ -40,7 +37,9 @@ internal sealed class TypeSymbolProcessor
         
         DefaultBitOrder = (BitOrder)attribute.ConstructorArguments[0].Value!;
         IsStruct = typeSymbol.TypeKind == TypeKind.Struct;
-        IsInlineArray = HasInlineArrayAttribute();
+        IsInlineArray = HasInlineArrayAttribute(typeSymbol);
+        
+        EnumerateFields(typeSymbol);
     }
 
     public void GenerateCSharpSource(StringBuilder sb)
@@ -59,11 +58,11 @@ internal sealed class TypeSymbolProcessor
           .AppendLine();
     }
 
-    public int EnumerateFields()
+    private int EnumerateFields(ITypeSymbol typeSymbol)
     {
         _fields.Clear();
 
-        foreach (IFieldSymbol field in TypeSymbol.GetMembers().OfType<IFieldSymbol>())
+        foreach (IFieldSymbol field in typeSymbol.GetMembers().OfType<IFieldSymbol>())
         {
             if (!IsValidFieldSymbol(field))
                 continue;
@@ -144,9 +143,9 @@ internal sealed class TypeSymbolProcessor
         };
     }
 
-    private bool HasInlineArrayAttribute()
+    private static bool HasInlineArrayAttribute(ITypeSymbol typeSymbol)
     {
-        return (int?)TypeSymbol
+        return (int?)typeSymbol
             .GetAttributes()
             .FirstOrDefault(a => a.AttributeClass?.ToDisplayString() == StringConstants.InlineArrayAttributeFullName)?
             .ConstructorArguments[0].Value > 0;

--- a/BitsKit.Tests/BitsKit.Tests.csproj
+++ b/BitsKit.Tests/BitsKit.Tests.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <Platforms>AnyCPU;x86;x64</Platforms>
 	<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 	<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-	<LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BitsKit.Tests/GeneratorTests.cs
+++ b/BitsKit.Tests/GeneratorTests.cs
@@ -261,7 +261,7 @@ public class GeneratorTests
         }
         ";
 
-        string? sourceOutput = GenerateSourceAndTest(source, new BitObjectGenerator());
+        string? sourceOutput = GenerateSourceAndTest(source);
 
         Assert.IsTrue(Helpers.StrEqualExWhiteSpace(sourceOutput, expected));
     }
@@ -304,7 +304,7 @@ public class GeneratorTests
         }
         ";
 
-        string? sourceOutput = GenerateSourceAndTest(source, new BitObjectGenerator());
+        string? sourceOutput = GenerateSourceAndTest(source);
 
         Assert.IsTrue(Helpers.StrEqualExWhiteSpace(sourceOutput, expected));
     }
@@ -461,7 +461,7 @@ public class GeneratorTests
         }
         ";
 
-        string? sourceOutput = GenerateSourceAndTest(source, new BitObjectGenerator());
+        string? sourceOutput = GenerateSourceAndTest(source);
 
         Assert.IsTrue(Helpers.StrEqualExWhiteSpace(sourceOutput, expected));
     }
@@ -553,7 +553,7 @@ public class GeneratorTests
         }
         ";
 
-        string? sourceOutput = GenerateSourceAndTest(source, new BitObjectGenerator());
+        string? sourceOutput = GenerateSourceAndTest(source);
 
         Assert.IsTrue(Helpers.StrEqualExWhiteSpace(sourceOutput, expected));
 #endif
@@ -608,7 +608,7 @@ public class GeneratorTests
         }
         ";
 
-        string? sourceOutput = GenerateSourceAndTest(source, new BitObjectGenerator());
+        string? sourceOutput = GenerateSourceAndTest(source);
 
         Assert.IsTrue(Helpers.StrEqualExWhiteSpace(sourceOutput, expected));
     }
@@ -689,7 +689,7 @@ public class GeneratorTests
         }
         ";
 
-        string? sourceOutput = GenerateSourceAndTest(source, new BitObjectGenerator());
+        string? sourceOutput = GenerateSourceAndTest(source);
 
         Assert.IsTrue(Helpers.StrEqualExWhiteSpace(sourceOutput, expected));
     }
@@ -726,7 +726,7 @@ public class GeneratorTests
         }
         ";
 
-        string? sourceOutput = GenerateSourceAndTest(source, new BitObjectGenerator());
+        string? sourceOutput = GenerateSourceAndTest(source);
 
         Assert.IsTrue(Helpers.StrEqualExWhiteSpace(sourceOutput, expected));
     }
@@ -778,51 +778,93 @@ public class GeneratorTests
         }
         ";
 
-        string? sourceOutput = GenerateSourceAndTest(source, new BitObjectGenerator());
+        string? sourceOutput = GenerateSourceAndTest(source);
 
         Assert.IsTrue(Helpers.StrEqualExWhiteSpace(sourceOutput, expected));
     }
 
 #endif
 
-    private static string? GenerateSourceAndTest(string source, IIncrementalGenerator generator)
+    private static string? GenerateSourceAndTest(string source)
     {
         var references = AppDomain.CurrentDomain.GetAssemblies()
                                   .Where(assembly => !assembly.IsDynamic)
                                   .Select(assembly => MetadataReference.CreateFromFile(assembly.Location))
                                   .Cast<MetadataReference>();
 
-        CSharpCompilation compilation = CSharpCompilation.Create("compilation",
-                                        [CSharpSyntaxTree.ParseText(Helpers.GeneratorTestHeader + source)],
-                                        references,
-                                        new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "BitsKit.Tests.InMemory",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(Helpers.GeneratorTestHeader + source)],
+            references: references,
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true
+            )
+        );
+        
+        var insignificantEditComp = compilation.Clone()
+            .AddSyntaxTrees(CSharpSyntaxTree.ParseText("// dummy"));
 
-        GeneratorDriver driver = CSharpGeneratorDriver
-           .Create(generator)
-           .RunGeneratorsAndUpdateCompilation(compilation, out Compilation? outputCompilation, out ImmutableArray<Diagnostic> diagnostics);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            generators: [new BitObjectGenerator().AsSourceGenerator()],
+            driverOptions: new GeneratorDriverOptions(default, trackIncrementalGeneratorSteps: true));
 
-        var diag = outputCompilation.GetDiagnostics();
+        var run1Result = RunGenerator(ref driver, compilation);
+        var run2Result = RunGenerator(ref driver, insignificantEditComp);
+        
+        foreach (var outputStep in run2Result.Results[0].TrackedOutputSteps)
+        {
+            AssertGeneratorDidntRun(outputStep.Value);
+        }
+        AssertGeneratorDidntRun(run2Result.Results[0].TrackedSteps["Main"]);
+        
+        Assert.AreEqual(run1Result.GeneratedTrees.Length, 1);
+        Assert.IsTrue(run1Result.Diagnostics.IsEmpty);
 
-        Assert.IsTrue(diagnostics.IsEmpty); // there were no diagnostics created by the generators
-        Assert.AreEqual(outputCompilation.SyntaxTrees.Count(), 2); // we have two syntax trees, the original 'user' provided one, and the one added by the generator
-        Assert.IsTrue(outputCompilation.GetDiagnostics().IsEmpty); // verify the compilation with the added source has no diagnostics
-
-        GeneratorDriverRunResult runResult = driver.GetRunResult();
-
-        Assert.AreEqual(runResult.GeneratedTrees.Length, 1);
-        Assert.IsTrue(runResult.Diagnostics.IsEmpty);
-
-        GeneratorRunResult generatorResult = runResult.Results[0];
+        GeneratorRunResult generatorResult = run1Result.Results[0];
         Assert.AreEqual(generatorResult.Generator.GetGeneratorType(), typeof(BitObjectGenerator));
         Assert.IsTrue(generatorResult.Diagnostics.IsEmpty);
         Assert.AreEqual(generatorResult.GeneratedSources.Length, 1);
         Assert.IsTrue(generatorResult.Exception is null);
 
         string sourceOutput = generatorResult.GeneratedSources[0].SourceText.ToString();
-
         return TruncateUsings(sourceOutput);
     }
+    
+    private static GeneratorDriverRunResult RunGenerator(
+        ref GeneratorDriver driver,
+        Compilation compilation
+    )
+    {
+        driver = driver
+            .RunGeneratorsAndUpdateCompilation(
+                compilation,
+                out var outputCompilation,
+                out var diagnostics
+            );
 
+        // verify the compilation with the added source has no diagnostics
+        Assert.IsFalse(
+            outputCompilation
+                .GetDiagnostics()
+                .Any(d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning)
+        );
+
+        // there were no diagnostics created by the generators
+        Assert.IsTrue(diagnostics.IsEmpty);
+        
+        return driver.GetRunResult();
+    }
+    
+    private static void AssertGeneratorDidntRun(ImmutableArray<IncrementalGeneratorRunStep> steps)
+    {
+        var outputs = steps.SelectMany(o => o.Outputs);
+        foreach (var output in outputs)
+        {
+            Assert.IsTrue(output.Reason == IncrementalStepRunReason.Unchanged || 
+                          output.Reason == IncrementalStepRunReason.Cached);
+        }
+    }
+    
     private static string? TruncateUsings(string? source)
     {
         if (string.IsNullOrEmpty(source))

--- a/BitsKit.Tests/GeneratorTests.cs
+++ b/BitsKit.Tests/GeneratorTests.cs
@@ -833,8 +833,8 @@ public class GeneratorTests
 
         return source[eol..].TrimStart();
     }
-
-    /// <summary>Loads the BitsKit.Generator assembly into the current AppDomain</summary>
-    [BitObject(BitOrder.LeastSignificant)]
-    private readonly partial struct BitsKitGeneratorStub { }
 }
+
+/// <summary>Loads the BitsKit.Generator assembly into the current AppDomain</summary>
+[BitObject(BitOrder.LeastSignificant)]
+internal readonly partial struct BitsKitGeneratorStub { }

--- a/BitsKit.Tests/GeneratorTests.cs
+++ b/BitsKit.Tests/GeneratorTests.cs
@@ -242,7 +242,7 @@ public class GeneratorTests
         ";
 
         string expected = @"
-        public ref partial struct  BitFieldReadOnly
+        partial struct BitFieldReadOnly
         {
             public  Int32 Generated00 
             {
@@ -285,7 +285,7 @@ public class GeneratorTests
         ";
 
         string expected = @"
-        public readonly ref partial struct  BitFieldReadOnly
+        partial struct BitFieldReadOnly
         {
             public  Int32 Generated00 
             {
@@ -344,7 +344,7 @@ public class GeneratorTests
         ";
 
         string expected = @"
-        public unsafe partial class  BitFieldGeneratorTest
+        partial class BitFieldGeneratorTest
         {
             public  Int32 Generated01 
             {
@@ -490,7 +490,7 @@ public class GeneratorTests
         ";
 
         string expected = @"
-        public unsafe partial class  BitFieldGeneratorTest
+        partial class BitFieldGeneratorTest
         {
             public  Int32 Generated01 
             {
@@ -581,7 +581,7 @@ public class GeneratorTests
         ";
 
         string expected = @"
-        public unsafe ref partial struct  BooleanGeneratorTest
+        partial struct BooleanGeneratorTest
         {
             public  System.Boolean Generated01 
             {
@@ -639,7 +639,7 @@ public class GeneratorTests
         ";
 
         string expected = @"
-        public unsafe ref partial struct  EnumGeneratorTest
+        partial struct EnumGeneratorTest
         {
             public  BitsKit.Tests.TestEnum Generated00 
             {
@@ -710,7 +710,7 @@ public class GeneratorTests
         ";
 
         string expected = @"
-        public ref partial struct  BitFieldIntegerConversion
+        partial struct BitFieldIntegerConversion
         {
             public  Byte Generated00 
             {
@@ -750,7 +750,7 @@ public class GeneratorTests
         ";
 
         string expected = @"
-        public partial struct  BitFieldInlineArray
+        partial struct BitFieldInlineArray
         {
             public  Int32 Generated00 
             {

--- a/BitsKit/BitsKit.csproj
+++ b/BitsKit/BitsKit.csproj
@@ -3,10 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <Platforms>AnyCPU;x86;x64</Platforms>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,7 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Thanks for this library, its a great help when working with bitfields. *However*, the current source generator has major issues and is not functioning incrementally.

- Storing `ISymbol` in incremental pipelines is not allowed.
- Storing `SyntaxNode`s in incremental pipelines is not allowed.
- Storing `List<T>` in incremental pipelines is not allowed.
- Using `CompilationProvider` causes the generator to re-run for every keystroke in the IDE.
- Diagnostics should be reported from analysers (because its almost impossible to get it working incrementally in a generator)

See all the linked discussion from https://github.com/dotnet/roslyn/issues/71629, and the [incremental generators cookboook](github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.cookbook.md). I have added a test that validates that the generator keeps working incrementally from this point forwards.

The one thing I haven't kept working is the `FieldTypeNotDefined`/`Cannot infer FieldType`/`"'{0}.{1}' FieldType cannot be inferred"` diagnostic. I am happy to fix it but I couldn't figure out in what situation it's supposed to be reported...